### PR TITLE
Changed HealthChecks to be represented as a list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ branches:
   only:
     - master
 
+dist: trusty
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ branches:
   only:
     - master
 
-sudo: required
-
 services:
   - docker
 

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -48,6 +48,6 @@ object ConsulOp {
   def healthCheck(service: String): ConsulOpF[String] =
     Free.liftFC(HealthCheck(service))
 
-  def healthCheckJson[A:DecodeJson](service: String): ConsulOpF[Err \/ SSet[A]] =
-    healthCheck(service).map(_.decodeEither[SSet[A]])
+  def healthCheckJson[A:DecodeJson](service: String): ConsulOpF[Err \/ List[A]] =
+    healthCheck(service).map(_.decodeEither[List[A]])
 }

--- a/core/src/test/scala/ConsulOpTests.scala
+++ b/core/src/test/scala/ConsulOpTests.scala
@@ -1,6 +1,5 @@
 package helm
 
-import scala.collection.immutable.{Set => SSet}
 import argonaut._, Argonaut._
 import scalaz.\/
 import scalaz.concurrent.Task
@@ -46,7 +45,7 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
         case ConsulOp.HealthCheck("foo") => now("""[{"Status":"passing"},{"Status":"warning"}]""")
       }
     } yield ()
-    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(SSet(Passing,Warning)))
+    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(List(Passing,Warning)))
   }
 
   it should "return a error if status id not decodeable" in {
@@ -66,6 +65,6 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
         case ConsulOp.HealthCheck("foo") => now("""[]""")
       }
     } yield ()
-    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(SSet()))
+    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(List()))
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.0-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
Changed HealthChecks to be represented as a list (to preserve cardinality).

Note: This is an API breaking change, hence requiring a 1.3.0 => 1.4.0 version bump.

@timperrett @rossabaker @kaiserpelagic