### PR TITLE
Add current version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A native [Scala](http://scala-lang.org) client for interacting with [Consul](htt
 
 Add the following to your `build.sbt`:
 
-    libraryDependencies += "io.verizon.helm" %% "http4s" % "1.3.+"
+    libraryDependencies += "io.verizon.helm" %% "http4s" % "1.4.78-scalaz-7.1"
 
 The *Helm* binaries are located on maven central, so no additional resolvers are needed.
 


### PR DESCRIPTION
The previous version fails to resolve on maven central. Seems that the scalaz-7.1 suffix is also required.