### PR TITLE
Add Service Lookups (WIP)

### DIFF
--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -21,6 +21,10 @@ object ConsulOp {
 
   final case class HealthCheck(service: String) extends ConsulOp[String]
 
+  final case object GetCatalogServices extends ConsulOp[Option[String]]
+
+  final case class GetService(service: String) extends ConsulOp[Option[String]]
+
   type ConsulOpF[A] = Free.FreeC[ConsulOp, A]
   type ConsulOpC[A] = Coyoneda[ConsulOp, A]
 
@@ -50,4 +54,11 @@ object ConsulOp {
 
   def healthCheckJson[A:DecodeJson](service: String): ConsulOpF[Err \/ List[A]] =
     healthCheck(service).map(_.decodeEither[List[A]])
+
+  def getCatalogServices: ConsulOpF[Option[String]] =
+    Free.liftFC(GetCatalogServices)
+
+  def getService(service: String): ConsulOpF[Option[String]] = {
+    Free.liftFC(GetService(service))
+  }
 }

--- a/core/src/test/scala/ConsulOpTests.scala
+++ b/core/src/test/scala/ConsulOpTests.scala
@@ -67,4 +67,45 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
     } yield ()
     interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(List()))
   }
+
+  "catalogServices" should "return a vector of registered services" in {
+    val interp = for {
+      _ <- I.expectU[Option[String]] {
+        case ConsulOp.GetCatalogServices => now(Some("""{"consul":[],"service-name":["tag1","tag2"]}"""))
+      }
+    } yield ()
+    interp.run(getJson[Json]("service-name")).run should equal(\/.right(Some(List("tag1","tag2"))))
+  }
+
+  it should "get the details of a service" in {
+    val mockServiceResponse = """[
+                                |  {
+                                |    "ID": "25867a8d-d37e-4334-aead-cf85337b1909",
+                                |    "Node": "consul.docker",
+                                |    "Address": "172.18.0.3",
+                                |    "TaggedAddresses": {
+                                |      "lan": "172.18.0.3",
+                                |      "wan": "172.18.0.3"
+                                |    },
+                                |    "NodeMeta": {},
+                                |    "ServiceID": "service-name-tag1-8888",
+                                |    "ServiceName": "service-name",
+                                |    "ServiceTags": [
+                                |      "tag1",
+                                |      "tag2"
+                                |    ],
+                                |    "ServiceAddress": "",
+                                |    "ServicePort": 8888,
+                                |    "ServiceEnableTagOverride": false,
+                                |    "CreateIndex": 63567,
+                                |    "ModifyIndex": 63567
+                                |  }
+                                |]""".stripMargin
+//    val interp = for {
+//      _ <- I.expectU[Option[String]] {
+//        case ConsulOp.GetService("service-name") => now(Some(mockServiceResponse))
+//      }
+//    } yield ()
+//    interp.run(???) // How to decode an array?
+  }
 }


### PR DESCRIPTION
I would like to add the ability to query the service catalog in Consul. I tried adding the following, but I'm getting a test failure: "could not match expected pattern (ConsulOpTests.scala:73)". For the second test, I don't understand how to decode the JSON consul returns which doesn't have a key, but is just an array like in the mock response. 

Any help is greatly appreciated. I'm a little lost in functional land here. ;-)