### PR TITLE
Expanded the ConsulOp algebra to include a number of previously unsupported operations

### DIFF
--- a/core/src/main/scala/HealthCheckParameter.scala
+++ b/core/src/main/scala/HealthCheckParameter.scala
@@ -1,0 +1,39 @@
+package helm
+
+import argonaut._, Argonaut._
+
+/** Case class representing a health check as defined in the Register Service API calls */
+final case class HealthCheckParameter(
+  name:                           String,
+  id:                             Option[String],
+  interval:                       Option[Interval],
+  notes:                          Option[String],
+  deregisterCriticalServiceAfter: Option[Interval],
+  serviceId:                      Option[String],
+  initialStatus:                  Option[HealthStatus],
+  http:                           Option[String],
+  tlsSkipVerify:                  Option[Boolean],
+  script:                         Option[String],
+  dockerContainerId:              Option[String],
+  tcp:                            Option[String],
+  ttl:                            Option[Interval]
+)
+
+object HealthCheckParameter {
+  implicit def HealthCheckParameterEncoder: EncodeJson[HealthCheckParameter] =
+    EncodeJson((h: HealthCheckParameter) =>
+      ("Name"                           :=  h.name)                           ->:
+      ("CheckID"                        :=? h.id)                             ->?:
+      ("Interval"                       :=? h.interval)                       ->?:
+      ("Notes"                          :=? h.notes)                          ->?:
+      ("DeregisterCriticalServiceAfter" :=? h.deregisterCriticalServiceAfter) ->?:
+      ("ServiceID"                      :=? h.serviceId)                      ->?:
+      ("Status"                         :=? h.initialStatus)                  ->?:
+      ("HTTP"                           :=? h.http)                           ->?:
+      ("TLSSkipVerify"                  :=? h.tlsSkipVerify)                  ->?:
+      ("Script"                         :=? h.script)                         ->?:
+      ("DockerContainerID"              :=? h.dockerContainerId)              ->?:
+      ("TCP"                            :=? h.tcp)                            ->?:
+      ("TTL"                            :=? h.ttl)                            ->?:
+      jEmptyObject)
+}

--- a/core/src/main/scala/HealthCheckResponse.scala
+++ b/core/src/main/scala/HealthCheckResponse.scala
@@ -1,0 +1,48 @@
+package helm
+
+import argonaut._, Argonaut._
+
+/** Case class representing a health check as returned from an API call to Consul */
+final case class HealthCheckResponse(
+  node:        String,
+  checkId:     String,
+  name:        String,
+  status:      HealthStatus,
+  notes:       String,
+  output:      String,
+  serviceId:   String,
+  serviceName: String,
+  serviceTags: List[String],
+  createIndex: Long,
+  modifyIndex: Long
+)
+
+object HealthCheckResponse {
+  implicit def HealthCheckResponseDecoder: DecodeJson[HealthCheckResponse] =
+    DecodeJson(j =>
+      for {
+        node        <- (j --\ "Node").as[String]
+        checkId     <- (j --\ "CheckID").as[String]
+        name        <- (j --\ "Name").as[String]
+        status      <- (j --\ "Status").as[HealthStatus]
+        notes       <- (j --\ "Notes").as[String]
+        output      <- (j --\ "Output").as[String]
+        serviceId   <- (j --\ "ServiceID").as[String]
+        serviceName <- (j --\ "ServiceName").as[String]
+        serviceTags <- (j --\ "ServiceTags").as[List[String]]
+        createIndex <- (j --\ "CreateIndex").as[Long]
+        modifyIndex <- (j --\ "ModifyIndex").as[Long]
+      } yield HealthCheckResponse(
+        node,
+        checkId,
+        name,
+        status,
+        notes,
+        output,
+        serviceId,
+        serviceName,
+        serviceTags,
+        createIndex,
+        modifyIndex)
+    )
+}

--- a/core/src/main/scala/HealthNodesForServiceResponse.scala
+++ b/core/src/main/scala/HealthNodesForServiceResponse.scala
@@ -1,0 +1,21 @@
+package helm
+
+import argonaut._, Argonaut._
+
+/** Case class representing the response to the Health API's List Nodes For Service function */
+final case class HealthNodesForServiceResponse(
+  node:        NodeResponse,
+  service:     ServiceResponse,
+  checks:      List[HealthCheckResponse]
+)
+
+object HealthNodesForServiceResponse {
+  implicit def HealthNodesForServiceResponseDecoder: DecodeJson[HealthNodesForServiceResponse] =
+    DecodeJson(j =>
+      for {
+        node    <- (j --\ "Node").as[NodeResponse]
+        service <- (j --\ "Service").as[ServiceResponse]
+        checks  <- (j --\ "Checks").as[List[HealthCheckResponse]]
+      } yield HealthNodesForServiceResponse(node, service, checks)
+    )
+}

--- a/core/src/main/scala/HealthStatus.scala
+++ b/core/src/main/scala/HealthStatus.scala
@@ -3,7 +3,6 @@ package helm
 import scalaz._, Scalaz._
 import argonaut._, Argonaut._
 
-
 sealed abstract class HealthStatus extends Product with Serializable
 
 object HealthStatus {
@@ -22,6 +21,14 @@ object HealthStatus {
       case _          => None
     }
 
+  def toString(hs: HealthStatus): String =
+    hs match {
+      case Passing  => "passing"
+      case Warning  => "warning"
+      case Critical => "critical"
+      case Unknown  => "unknown"
+    }
+
   implicit val HealthStatusDecoder: DecodeJson[HealthStatus] =
     DecodeJson[HealthStatus] { c =>
       (c --\ "Status").as[String].flatMap { s =>
@@ -31,4 +38,7 @@ object HealthStatus {
         )
       }
     }
+
+  implicit val HealthStatusEncoder: EncodeJson[HealthStatus] =
+    EncodeJson[HealthStatus] { hs => jString(toString(hs)) }
 }

--- a/core/src/main/scala/HealthStatus.scala
+++ b/core/src/main/scala/HealthStatus.scala
@@ -31,7 +31,7 @@ object HealthStatus {
 
   implicit val HealthStatusDecoder: DecodeJson[HealthStatus] =
     DecodeJson[HealthStatus] { c =>
-      (c --\ "Status").as[String].flatMap { s =>
+      c.as[String].flatMap { s =>
         fromString(s).cata(
           some = r => DecodeResult.ok(r),
           none = DecodeResult.fail(s"invalid health status: $s", c.history)

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -24,11 +24,14 @@ object ConsulOp {
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
   final case class AgentRegisterService(
-    service: String,
-    id:      Option[String],
-    tags:    Option[NonEmptyList[String]],
-    address: Option[String],
-    port:    Option[Int]
+    service:           String,
+    id:                Option[String],
+    tags:              Option[NonEmptyList[String]],
+    address:           Option[String],
+    port:              Option[Int],
+    enableTagOverride: Option[Boolean],
+    check:             Option[HealthCheckParameter],
+    checks:            Option[NonEmptyList[HealthCheckParameter]]
   ) extends ConsulOp[Unit]
 
   final case class AgentDeregisterService(id: String) extends ConsulOp[Unit]
@@ -69,18 +72,22 @@ object ConsulOp {
     Free.liftFC(AgentListServices)
 
   def agentRegisterService(
-    service: String,
-    id:      Option[String],
-    tags:    Option[NonEmptyList[String]],
-    address: Option[String],
-    port:    Option[Int]
+    service:           String,
+    id:                Option[String],
+    tags:              Option[NonEmptyList[String]],
+    address:           Option[String],
+    port:              Option[Int],
+    enableTagOverride: Option[Boolean],
+    check:             Option[HealthCheckParameter],
+    checks:            Option[NonEmptyList[HealthCheckParameter]]
   ): ConsulOpF[Unit] =
-    Free.liftFC(AgentRegisterService(service, id, tags, address, port))
+    Free.liftFC(AgentRegisterService(service, id, tags, address, port, enableTagOverride, check, checks))
 
   def agentDeregisterService(id: String): ConsulOpF[Unit] =
     Free.liftFC(AgentDeregisterService(id))
 
   def agentEnableMaintenanceMode(id: String, enable: Boolean, reason: Option[String]): ConsulOpF[Unit] =
     Free.liftFC(AgentEnableMaintenanceMode(id, enable, reason))
-
 }
+
+

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -19,7 +19,7 @@ object ConsulOp {
 
   final case class ListKeys(prefix: Key) extends ConsulOp[SSet[String]]
 
-  final case class HealthCheck(service: String) extends ConsulOp[String]
+  final case class ListHealthChecksForService(service: String) extends ConsulOp[List[HealthCheckResponse]]
 
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
@@ -62,11 +62,8 @@ object ConsulOp {
   def listKeys(prefix: Key): ConsulOpF[SSet[String]] =
     Free.liftFC(ListKeys(prefix))
 
-  def healthCheck(service: String): ConsulOpF[String] =
-    Free.liftFC(HealthCheck(service))
-
-  def healthCheckJson[A:DecodeJson](service: String): ConsulOpF[Err \/ List[A]] =
-    healthCheck(service).map(_.decodeEither[List[A]])
+  def listHealthChecksForService(service: String): ConsulOpF[List[HealthCheckResponse]] =
+    Free.liftFC(ListHealthChecksForService(service))
 
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     Free.liftFC(AgentListServices)

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -11,27 +11,27 @@ sealed abstract class ConsulOp[A] extends Product with Serializable
 
 object ConsulOp {
 
-  final case class Get(key: Key) extends ConsulOp[Option[String]]
+  final case class KVGet(key: Key) extends ConsulOp[Option[String]]
 
-  final case class Set(key: Key, value: String) extends ConsulOp[Unit]
+  final case class KVSet(key: Key, value: String) extends ConsulOp[Unit]
 
-  final case class Delete(key: Key) extends ConsulOp[Unit]
+  final case class KVDelete(key: Key) extends ConsulOp[Unit]
 
-  final case class ListKeys(prefix: Key) extends ConsulOp[SSet[String]]
+  final case class KVListKeys(prefix: Key) extends ConsulOp[SSet[String]]
 
-  final case class ListHealthChecksForService(
+  final case class HealthListChecksForService(
     service:    String,
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String]
   ) extends ConsulOp[List[HealthCheckResponse]]
 
-  final case class ListHealthChecksForNode(
+  final case class HealthListChecksForNode(
     node:       String,
     datacenter: Option[String]
   ) extends ConsulOp[List[HealthCheckResponse]]
 
-  final case class ListHealthChecksInState(
+  final case class HealthListChecksInState(
     state:      HealthStatus,
     datacenter: Option[String],
     near:       Option[String],
@@ -71,45 +71,45 @@ object ConsulOp {
   // this shouldn't be necessary, but we need to help the compiler out a bit
   implicit val ConsulOpFMonad: Monad[ConsulOpF] = Free.freeMonad[ConsulOpC]
 
-  def get(key: Key): ConsulOpF[Option[String]] =
-    Free.liftFC(Get(key))
+  def kvGet(key: Key): ConsulOpF[Option[String]] =
+    Free.liftFC(KVGet(key))
 
-  def getJson[A:DecodeJson](key: Key): ConsulOpF[Err \/ Option[A]] =
-    get(key).map(_.traverseU(_.decodeEither[A]))
+  def kvGetJson[A:DecodeJson](key: Key): ConsulOpF[Err \/ Option[A]] =
+    kvGet(key).map(_.traverseU(_.decodeEither[A]))
 
-  def set(key: Key, value: String): ConsulOpF[Unit] =
-    Free.liftFC(Set(key, value))
+  def kvSet(key: Key, value: String): ConsulOpF[Unit] =
+    Free.liftFC(KVSet(key, value))
 
-  def setJson[A](key: Key, value: A)(implicit A: EncodeJson[A]): ConsulOpF[Unit] =
-    set(key, A.encode(value).toString)
+  def kvSetJson[A](key: Key, value: A)(implicit A: EncodeJson[A]): ConsulOpF[Unit] =
+    kvSet(key, A.encode(value).toString)
 
-  def delete(key: Key): ConsulOpF[Unit] =
-    Free.liftFC(Delete(key))
+  def kvDelete(key: Key): ConsulOpF[Unit] =
+    Free.liftFC(KVDelete(key))
 
-  def listKeys(prefix: Key): ConsulOpF[SSet[String]] =
-    Free.liftFC(ListKeys(prefix))
+  def kvListKeys(prefix: Key): ConsulOpF[SSet[String]] =
+    Free.liftFC(KVListKeys(prefix))
 
-  def listHealthChecksForService(
+  def healthListChecksForService(
     service:    String,
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String]
   ): ConsulOpF[List[HealthCheckResponse]] =
-    Free.liftFC(ListHealthChecksForService(service, datacenter, near, nodeMeta))
+    Free.liftFC(HealthListChecksForService(service, datacenter, near, nodeMeta))
 
-  def listHealthChecksForNode(
+  def healthListChecksForNode(
     node:       String,
     datacenter: Option[String]
   ): ConsulOpF[List[HealthCheckResponse]] =
-    Free.liftFC(ListHealthChecksForNode(node, datacenter))
+    Free.liftFC(HealthListChecksForNode(node, datacenter))
 
-  def listHealthChecksInState(
+  def healthListChecksInState(
     state:      HealthStatus,
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String]
   ): ConsulOpF[List[HealthCheckResponse]] =
-    Free.liftFC(ListHealthChecksInState(state, datacenter, near, nodeMeta))
+    Free.liftFC(HealthListChecksInState(state, datacenter, near, nodeMeta))
 
   def healthListNodesForService(
     service:     String,

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -19,7 +19,17 @@ object ConsulOp {
 
   final case class ListKeys(prefix: Key) extends ConsulOp[SSet[String]]
 
-  final case class ListHealthChecksForService(service: String) extends ConsulOp[List[HealthCheckResponse]]
+  final case class ListHealthChecksForService(
+    service:    String,
+    datacenter: Option[String],
+    near:       Option[String],
+    nodeMeta:   Option[String]
+  ) extends ConsulOp[List[HealthCheckResponse]]
+
+  final case class ListHealthChecksForNode(
+    node:       String,
+    datacenter: Option[String]
+  ) extends ConsulOp[List[HealthCheckResponse]]
 
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
@@ -62,8 +72,19 @@ object ConsulOp {
   def listKeys(prefix: Key): ConsulOpF[SSet[String]] =
     Free.liftFC(ListKeys(prefix))
 
-  def listHealthChecksForService(service: String): ConsulOpF[List[HealthCheckResponse]] =
-    Free.liftFC(ListHealthChecksForService(service))
+  def listHealthChecksForService(
+    service:    String,
+    datacenter: Option[String],
+    near:       Option[String],
+    nodeMeta:   Option[String]
+  ): ConsulOpF[List[HealthCheckResponse]] =
+    Free.liftFC(ListHealthChecksForService(service, datacenter, near, nodeMeta))
+
+  def listHealthChecksForNode(
+    node:       String,
+    datacenter: Option[String]
+  ): ConsulOpF[List[HealthCheckResponse]] =
+    Free.liftFC(ListHealthChecksForNode(node, datacenter))
 
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     Free.liftFC(AgentListServices)

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -31,6 +31,8 @@ object ConsulOp {
     port:    Option[Int]
   ) extends ConsulOp[Unit]
 
+  final case class AgentDeregisterService(id: String) extends ConsulOp[Unit]
+
   type ConsulOpF[A] = Free.FreeC[ConsulOp, A]
   type ConsulOpC[A] = Coyoneda[ConsulOp, A]
 
@@ -72,4 +74,9 @@ object ConsulOp {
     port:    Option[Int]
   ): ConsulOpF[Unit] =
     Free.liftFC(AgentRegisterService(service, id, tags, address, port))
+
+  def agentDeregisterService(
+    service: String
+  ): ConsulOpF[Unit] =
+    Free.liftFC(AgentDeregisterService(service))
 }

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -77,10 +77,8 @@ object ConsulOp {
   ): ConsulOpF[Unit] =
     Free.liftFC(AgentRegisterService(service, id, tags, address, port))
 
-  def agentDeregisterService(
-    service: String
-  ): ConsulOpF[Unit] =
-    Free.liftFC(AgentDeregisterService(service))
+  def agentDeregisterService(id: String): ConsulOpF[Unit] =
+    Free.liftFC(AgentDeregisterService(id))
 
   def agentEnableMaintenanceMode(id: String, enable: Boolean, reason: Option[String]): ConsulOpF[Unit] =
     Free.liftFC(AgentEnableMaintenanceMode(id, enable, reason))

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -21,6 +21,8 @@ object ConsulOp {
 
   final case class HealthCheck(service: String) extends ConsulOp[String]
 
+  final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
+
   final case class AgentRegisterService(
     service: String,
     id:      Option[String],
@@ -58,6 +60,9 @@ object ConsulOp {
 
   def healthCheckJson[A:DecodeJson](service: String): ConsulOpF[Err \/ List[A]] =
     healthCheck(service).map(_.decodeEither[List[A]])
+
+  def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
+    Free.liftFC(AgentListServices)
 
   def agentRegisterService(
     service: String,

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -33,6 +33,8 @@ object ConsulOp {
 
   final case class AgentDeregisterService(id: String) extends ConsulOp[Unit]
 
+  final case class AgentEnableMaintenanceMode(id: String, enable: Boolean, reason: Option[String]) extends ConsulOp[Unit]
+
   type ConsulOpF[A] = Free.FreeC[ConsulOp, A]
   type ConsulOpC[A] = Coyoneda[ConsulOp, A]
 
@@ -79,4 +81,8 @@ object ConsulOp {
     service: String
   ): ConsulOpF[Unit] =
     Free.liftFC(AgentDeregisterService(service))
+
+  def agentEnableMaintenanceMode(id: String, enable: Boolean, reason: Option[String]): ConsulOpF[Unit] =
+    Free.liftFC(AgentEnableMaintenanceMode(id, enable, reason))
+
 }

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -31,6 +31,13 @@ object ConsulOp {
     datacenter: Option[String]
   ) extends ConsulOp[List[HealthCheckResponse]]
 
+  final case class ListHealthChecksInState(
+    state:      HealthStatus,
+    datacenter: Option[String],
+    near:       Option[String],
+    nodeMeta:   Option[String]
+  ) extends ConsulOp[List[HealthCheckResponse]]
+
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
   final case class AgentRegisterService(
@@ -86,6 +93,14 @@ object ConsulOp {
   ): ConsulOpF[List[HealthCheckResponse]] =
     Free.liftFC(ListHealthChecksForNode(node, datacenter))
 
+  def listHealthChecksInState(
+    state:      HealthStatus,
+    datacenter: Option[String],
+    near:       Option[String],
+    nodeMeta:   Option[String]
+  ): ConsulOpF[List[HealthCheckResponse]] =
+    Free.liftFC(ListHealthChecksInState(state, datacenter, near, nodeMeta))
+
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     Free.liftFC(AgentListServices)
 
@@ -107,5 +122,3 @@ object ConsulOp {
   def agentEnableMaintenanceMode(id: String, enable: Boolean, reason: Option[String]): ConsulOpF[Unit] =
     Free.liftFC(AgentEnableMaintenanceMode(id, enable, reason))
 }
-
-

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -38,6 +38,16 @@ object ConsulOp {
     nodeMeta:   Option[String]
   ) extends ConsulOp[List[HealthCheckResponse]]
 
+  // There's also a Catalog function called List Nodes for Service
+  final case class HealthListNodesForService(
+    service:     String,
+    datacenter:  Option[String],
+    near:        Option[String],
+    nodeMeta:    Option[String],
+    tag:         Option[String],
+    passingOnly: Option[Boolean]
+  ) extends ConsulOp[List[HealthNodesForServiceResponse]]
+
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
   final case class AgentRegisterService(
@@ -100,6 +110,16 @@ object ConsulOp {
     nodeMeta:   Option[String]
   ): ConsulOpF[List[HealthCheckResponse]] =
     Free.liftFC(ListHealthChecksInState(state, datacenter, near, nodeMeta))
+
+  def healthListNodesForService(
+    service:     String,
+    datacenter:  Option[String],
+    near:        Option[String],
+    nodeMeta:    Option[String],
+    tag:         Option[String],
+    passingOnly: Option[Boolean]
+  ): ConsulOpF[List[HealthNodesForServiceResponse]] =
+    Free.liftFC(HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly))
 
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     Free.liftFC(AgentListServices)

--- a/core/src/main/scala/Interval.scala
+++ b/core/src/main/scala/Interval.scala
@@ -1,0 +1,36 @@
+package helm
+
+import scalaz._, Scalaz._
+import argonaut._, Argonaut._
+
+sealed abstract class Interval
+
+/** Some types to represent check intervals, et al. */
+object Interval {
+
+  // So I considered using Scala's FiniteDuration type, but it
+  // seems like overkill.
+  // Also note that Consul supports intervals like "2h45m",
+  // seemingly because Go's time formatting library does,
+  // but that doesn't seem useful in a health check interval.
+  final case class Nanoseconds(value: Double) extends Interval
+  final case class Microseconds(value: Double) extends Interval
+  final case class Milliseconds(value: Double) extends Interval
+  final case class Seconds(value: Double) extends Interval
+  final case class Minutes(value: Double) extends Interval
+  final case class Hours(value: Double) extends Interval
+
+  def toString(i: Interval): String = {
+    i match {
+      case Nanoseconds(v)  => f"${v}%fns"
+      case Microseconds(v) => f"${v}%fus"
+      case Milliseconds(v) => f"${v}%fms"
+      case Seconds(v)      => f"${v}%fs"
+      case Minutes(v)      => f"${v}%fm"
+      case Hours(v)        => f"${v}%fh"
+    }
+  }
+
+  implicit val IntervalEncoder: EncodeJson[Interval] =
+    EncodeJson[Interval] { i => jString(toString(i)) }
+}

--- a/core/src/main/scala/NodeResponse.scala
+++ b/core/src/main/scala/NodeResponse.scala
@@ -1,0 +1,51 @@
+package helm
+
+import argonaut._, Argonaut._
+
+/** Case class representing a health check as returned from an API call to Consul */
+final case class NodeResponse(
+  id:              String,
+  node:            String,
+  address:         String,
+  datacenter:      String,
+  meta:            Map[String, String],
+  taggedAddresses: TaggedAddresses,
+  createIndex:     Long,
+  modifyIndex:     Long
+)
+
+object NodeResponse {
+  implicit def NodeResponseDecoder: DecodeJson[NodeResponse] =
+    DecodeJson(j =>
+      for {
+        id              <- (j --\ "ID").as[String]
+        node            <- (j --\ "Node").as[String]
+        address         <- (j --\ "Address").as[String]
+        datacenter      <- (j --\ "Datacenter").as[String]
+        meta            <- (j --\ "Meta").as[Map[String, String]]
+        taggedAddresses <- (j --\ "TaggedAddresses").as[TaggedAddresses]
+        createIndex     <- (j --\ "CreateIndex").as[Long]
+        modifyIndex     <- (j --\ "ModifyIndex").as[Long]
+      } yield NodeResponse(
+        id,
+        node,
+        address,
+        datacenter,
+        meta,
+        taggedAddresses,
+        createIndex,
+        modifyIndex)
+    )
+}
+
+final case class TaggedAddresses(lan: String, wan: String)
+
+object TaggedAddresses {
+  implicit def TaggedAddressesDecoder: DecodeJson[TaggedAddresses] =
+    DecodeJson(j =>
+      for {
+        lan <- (j --\ "lan").as[String]
+        wan <- (j --\ "wan").as[String]
+      } yield TaggedAddresses(lan, wan)
+    )
+}

--- a/core/src/main/scala/ServiceResponse.scala
+++ b/core/src/main/scala/ServiceResponse.scala
@@ -1,0 +1,30 @@
+package helm
+
+import scalaz._, Scalaz._
+import argonaut._, Argonaut._
+
+final case class ServiceResponse(
+  service:           String,
+  id:                String,
+  tags:              List[String],
+  address:           String,
+  port:              Int,
+  enableTagOverride: Boolean,
+  modifyIndex:       Int
+)
+
+object ServiceResponse {
+
+  implicit def ServiceResponseDecoder: DecodeJson[ServiceResponse] =
+    DecodeJson(j =>
+      for {
+        id                <- (j --\ "ID").as[String]
+        address           <- (j --\ "Address").as[String]
+        enableTagOverride <- (j --\ "EnableTagOverride").as[Boolean]
+        modifyIndex       <- (j --\ "ModifyIndex").as[Int]
+        port              <- (j --\ "Port").as[Int]
+        service           <- (j --\ "Service").as[String]
+        tags              <- (j --\ "Tags").as[List[String]]
+      } yield ServiceResponse(service, id, tags, address, port, enableTagOverride, modifyIndex)
+    )
+}

--- a/core/src/main/scala/ServiceResponse.scala
+++ b/core/src/main/scala/ServiceResponse.scala
@@ -1,9 +1,8 @@
 package helm
 
-import scalaz._, Scalaz._
 import argonaut._, Argonaut._
 
-/** Case class representing the representation of a service as returned from an API call to Consul */
+/** Case class representing a service as returned from an API call to Consul */
 final case class ServiceResponse(
   service:           String,
   id:                String,

--- a/core/src/main/scala/ServiceResponse.scala
+++ b/core/src/main/scala/ServiceResponse.scala
@@ -3,6 +3,7 @@ package helm
 import scalaz._, Scalaz._
 import argonaut._, Argonaut._
 
+/** Case class representing the representation of a service as returned from an API call to Consul */
 final case class ServiceResponse(
   service:           String,
   id:                String,
@@ -14,7 +15,6 @@ final case class ServiceResponse(
 )
 
 object ServiceResponse {
-
   implicit def ServiceResponseDecoder: DecodeJson[ServiceResponse] =
     DecodeJson(j =>
       for {

--- a/core/src/main/scala/ServiceResponse.scala
+++ b/core/src/main/scala/ServiceResponse.scala
@@ -10,7 +10,8 @@ final case class ServiceResponse(
   address:           String,
   port:              Int,
   enableTagOverride: Boolean,
-  modifyIndex:       Int
+  createIndex:       Long,
+  modifyIndex:       Long
 )
 
 object ServiceResponse {
@@ -20,10 +21,11 @@ object ServiceResponse {
         id                <- (j --\ "ID").as[String]
         address           <- (j --\ "Address").as[String]
         enableTagOverride <- (j --\ "EnableTagOverride").as[Boolean]
-        modifyIndex       <- (j --\ "ModifyIndex").as[Int]
+        createIndex       <- (j --\ "CreateIndex").as[Long]
+        modifyIndex       <- (j --\ "ModifyIndex").as[Long]
         port              <- (j --\ "Port").as[Int]
         service           <- (j --\ "Service").as[String]
         tags              <- (j --\ "Tags").as[List[String]]
-      } yield ServiceResponse(service, id, tags, address, port, enableTagOverride, modifyIndex)
+      } yield ServiceResponse(service, id, tags, address, port, enableTagOverride, createIndex, modifyIndex)
     )
 }

--- a/core/src/test/scala/ConsulOpTests.scala
+++ b/core/src/test/scala/ConsulOpTests.scala
@@ -37,34 +37,4 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
     } yield ()
     interp.run(getJson[Json]("foo")).run should equal(\/.left("JSON terminates unexpectedly."))
   }
-
-  "healthCheck" should "return a vector of health status values when decodeable" in {
-    import HealthStatus._
-    val interp = for {
-      _ <- I.expectU[String] {
-        case ConsulOp.HealthCheck("foo") => now("""[{"Status":"passing"},{"Status":"warning"}]""")
-      }
-    } yield ()
-    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(List(Passing,Warning)))
-  }
-
-  it should "return a error if status id not decodeable" in {
-    import HealthStatus._
-    val interp = for {
-      _ <- I.expectU[String] {
-        case ConsulOp.HealthCheck("foo") => now("""[{"Status":"bar"}]""")
-      }
-    } yield ()
-    interp.run(healthCheckJson[HealthStatus]("foo")).run.isLeft should equal(true)
-  }
-
-  it should "return a empty set if response is empty" in {
-    import HealthStatus._
-    val interp = for {
-      _ <- I.expectU[String] {
-        case ConsulOp.HealthCheck("foo") => now("""[]""")
-      }
-    } yield ()
-    interp.run(healthCheckJson[HealthStatus]("foo")).run should equal(\/.right(List()))
-  }
 }

--- a/core/src/test/scala/ConsulOpTests.scala
+++ b/core/src/test/scala/ConsulOpTests.scala
@@ -14,27 +14,27 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
   "getJson" should "return none right when get returns None" in {
     val interp = for {
       _ <- I.expectU[Option[String]] {
-        case ConsulOp.Get("foo") => now(None)
+        case ConsulOp.KVGet("foo") => now(None)
       }
     } yield ()
-    interp.run(getJson[Json]("foo")).run should equal(\/.right(None))
+    interp.run(kvGetJson[Json]("foo")).run should equal(\/.right(None))
   }
 
   it should "return a value when get returns a decodeable value" in {
     val interp = for {
       _ <- I.expectU[Option[String]] {
-        case ConsulOp.Get("foo") => now(Some("42"))
+        case ConsulOp.KVGet("foo") => now(Some("42"))
       }
     } yield ()
-    interp.run(getJson[Json]("foo")).run should equal(\/.right(Some(jNumber(42))))
+    interp.run(kvGetJson[Json]("foo")).run should equal(\/.right(Some(jNumber(42))))
   }
 
   it should "return an error when get returns a non-decodeable value" in {
     val interp = for {
       _ <- I.expectU[Option[String]] {
-        case ConsulOp.Get("foo") => now(Some("{"))
+        case ConsulOp.KVGet("foo") => now(Some("{"))
       }
     } yield ()
-    interp.run(getJson[Json]("foo")).run should equal(\/.left("JSON terminates unexpectedly."))
+    interp.run(kvGetJson[Json]("foo")).run should equal(\/.left("JSON terminates unexpectedly."))
   }
 }

--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -34,8 +34,8 @@ final class Http4sConsulClient(baseUri: Uri,
     case ConsulOp.ListKeys(prefix)                => list(prefix)
     case ConsulOp.Delete(key)                     => delete(key)
     case ConsulOp.HealthCheck(service)            => healthCheck(service)
-    case ConsulOp.AgentRegisterService(service, id, tags, address, port) =>
-      agentRegisterService(service, id, tags, address, port)
+    case ConsulOp.AgentRegisterService(service, id, tags, address, port, enableTagOverride, check, checks) =>
+      agentRegisterService(service, id, tags, address, port, enableTagOverride, check, checks)
     case ConsulOp.AgentDeregisterService(service) => agentDeregisterService(service)
     case ConsulOp.AgentListServices               => agentListServices()
     case ConsulOp.AgentEnableMaintenanceMode(id, enable, reason) =>
@@ -104,18 +104,24 @@ final class Http4sConsulClient(baseUri: Uri,
   }
 
   def agentRegisterService(
-    service: String,
-    id:      Option[String],
-    tags:    Option[NonEmptyList[String]],
-    address: Option[String],
-    port:    Option[Int]
+    service:           String,
+    id:                Option[String],
+    tags:              Option[NonEmptyList[String]],
+    address:           Option[String],
+    port:              Option[Int],
+    enableTagOverride: Option[Boolean],
+    check:             Option[HealthCheckParameter],
+    checks:            Option[NonEmptyList[HealthCheckParameter]]
   ): Task[Unit] = {
     val json: Json =
-      ("Name"    :=  service)          ->:
-      ("ID"      :=? id)               ->?:
-      ("Tags"    :=? tags.map(_.list)) ->?:
-      ("Address" :=? address)          ->?:
-      ("Port"    :=? port)             ->?:
+      ("Name"              :=  service)           ->:
+      ("ID"                :=? id)                ->?:
+      ("Tags"              :=? tags.map(_.list))  ->?:
+      ("Address"           :=? address)           ->?:
+      ("Port"              :=? port)              ->?:
+      ("EnableTagOverride" :=? enableTagOverride) ->?:
+      ("Check"             :=? check)             ->?:
+      ("Checks"            :=? checks)            ->?:
       jEmptyObject
 
     for {

--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -128,12 +128,10 @@ final class Http4sConsulClient(baseUri: Uri,
     } yield log.debug(s"registering service $service resulted in response $response")
   }
 
-  def agentDeregisterService(
-    service: String
-  ): Task[Unit] = {
-    val req = addCreds(addConsulToken(Request(Method.PUT, uri = (baseUri / "v1" / "agent" / "service" / "deregister" / service))))
+  def agentDeregisterService(id: String): Task[Unit] = {
+    val req = addCreds(addConsulToken(Request(Method.PUT, uri = (baseUri / "v1" / "agent" / "service" / "deregister" / id))))
     for {
-      _ <- Task.delay(log.debug(s"deregistering $service"))
+      _ <- Task.delay(log.debug(s"deregistering service with id $id"))
       response <- client.expect[String](req)
     } yield log.debug(s"response from deregister: " + response)
   }

--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -172,7 +172,7 @@ final class Http4sConsulClient(baseUri: Uri,
               .+??("near", near)
               .+??("node-meta", nodeMeta)
               .+??("tag", tag)
-              .+??("passingOnly", passingOnly))))
+              .+??("passing", passingOnly.filter(identity))))) // all values of passing parameter are treated the same by Consul
       response <- client.expect[List[HealthNodesForServiceResponse]](req)
     } yield {
       log.debug(s"health check response: " + response)

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -47,6 +47,20 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
     helm.run(csl, ConsulOp.set("foo", "bar")).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
+
+  "agentRegisterService" should "succeed when the response is 200" in {
+    val response = consulResponse(Status.Ok, "yay")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None)).attemptRun should ===(
+      \/.right(()))
+  }
+
+  it should "fail when the response is 500" in {
+    val response = consulResponse(Status.InternalServerError, "boo")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None)).attemptRun should ===(
+      \/.left(UnexpectedStatus(Status.InternalServerError)))
+  }
 }
 
 object Http4sConsulTests {

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -52,34 +52,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
     val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.listHealthChecksForNode("localhost", None)).attemptRun should ===(
-      \/.right(
-        List(
-          HealthCheckResponse(
-            "localhost",
-            "service:testService",
-            "Service 'testService' check",
-            HealthStatus.Passing,
-            "test note",
-            "HTTP GET https://test.test.test/: 200 OK Output: all's well",
-            "testServiceID",
-            "testServiceName",
-            List("testTag"),
-            19008L,
-            19013L),
-          HealthCheckResponse(
-            "localhost",
-            "service:testService#2",
-            "other check",
-            HealthStatus.Critical,
-            "a note",
-            "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
-            "testServiceID",
-            "testServiceName",
-            List("testTag", "anotherTag"),
-            123455121300L,
-            123455121321L)
-        )
-      ))
+      \/.right(dummyHealthStatusResponse))
   }
 
   it should "fail when the response is 500" in {
@@ -89,38 +62,25 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
+  "listHealthChecksInState" should "succeed with the proper result when the response is 200" in {
+    val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.listHealthChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
+      \/.right(dummyHealthStatusResponse))
+  }
+
+  it should "fail when the response is 500" in {
+    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.listHealthChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
+      \/.left(UnexpectedStatus(Status.InternalServerError)))
+  }
+
   "listHealthChecksForService" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.listHealthChecksForService("test", None, None, None)).attemptRun should ===(
-      \/.right(
-        List(
-          HealthCheckResponse(
-            "localhost",
-            "service:testService",
-            "Service 'testService' check",
-            HealthStatus.Passing,
-            "test note",
-            "HTTP GET https://test.test.test/: 200 OK Output: all's well",
-            "testServiceID",
-            "testServiceName",
-            List("testTag"),
-            19008L,
-            19013L),
-          HealthCheckResponse(
-            "localhost",
-            "service:testService#2",
-            "other check",
-            HealthStatus.Critical,
-            "a note",
-            "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
-            "testServiceID",
-            "testServiceName",
-            List("testTag", "anotherTag"),
-            123455121300L,
-            123455121321L)
-        )
-      ))
+      \/.right(dummyHealthStatusResponse))
   }
 
   it should "fail when the response is 500" in {
@@ -276,5 +236,34 @@ object Http4sConsulTests {
       }
   ]
   """
+
+  val dummyHealthStatusResponse =
+    List(
+      HealthCheckResponse(
+        "localhost",
+        "service:testService",
+        "Service 'testService' check",
+        HealthStatus.Passing,
+        "test note",
+        "HTTP GET https://test.test.test/: 200 OK Output: all's well",
+        "testServiceID",
+        "testServiceName",
+        List("testTag"),
+        19008L,
+        19013L),
+      HealthCheckResponse(
+        "localhost",
+        "service:testService#2",
+        "other check",
+        HealthStatus.Critical,
+        "a note",
+        "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
+        "testServiceID",
+        "testServiceName",
+        List("testTag", "anotherTag"),
+        123455121300L,
+        123455121321L)
+    )
+
 
 }

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -49,10 +49,10 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   }
 
   "listHealthChecksForNode" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.listHealthChecksForNode("localhost", None)).attemptRun should ===(
-      \/.right(dummyHealthStatusResponse))
+      \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
@@ -63,10 +63,10 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   }
 
   "listHealthChecksInState" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.listHealthChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
-      \/.right(dummyHealthStatusResponse))
+      \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
@@ -77,10 +77,10 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   }
 
   "listHealthChecksForService" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, dummyServiceHealthChecksReply)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.listHealthChecksForService("test", None, None, None)).attemptRun should ===(
-      \/.right(dummyHealthStatusResponse))
+      \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
@@ -91,7 +91,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   }
 
   "healthListNodesForService" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, healthNodesForServiceJsonResponse)
+    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson)
     val csl = constantConsul(response)
     helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None)).attemptRun should ===(
       \/.right(healthNodesForServiceReturnValue))
@@ -220,7 +220,7 @@ object Http4sConsulTests {
   }
   """
 
-  val dummyServiceHealthChecksReply = """
+  val serviceHealthChecksReplyJson = """
   [
       {
           "CheckID": "service:testService",
@@ -252,7 +252,7 @@ object Http4sConsulTests {
   """
 
 
-  val healthNodesForServiceJsonResponse = """
+  val healthNodesForServiceReplyJson = """
   [
       {
           "Checks": [
@@ -368,7 +368,7 @@ object Http4sConsulTests {
       )
     )
 
-  val dummyHealthStatusResponse =
+  val healthStatusReplyJson =
     List(
       HealthCheckResponse(
         "localhost",

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -51,14 +51,14 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   "agentRegisterService" should "succeed when the response is 200" in {
     val response = consulResponse(Status.Ok, "yay")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None, None, None, None)).attemptRun should ===(
       \/.right(()))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "boo")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.agentRegisterService("testService", Some("testId"), None, None, None, None, None, None)).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -76,6 +76,20 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
+  "agentEnableMaintenanceMode" should "succeed when the response is 200" in {
+    val response = consulResponse(Status.Ok, "")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentEnableMaintenanceMode("testService", true, None)).attemptRun should ===(
+      \/.right(()))
+  }
+
+  it should "fail when the response is 500" in {
+    val response = consulResponse(Status.InternalServerError, "")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentEnableMaintenanceMode("testService", true, None)).attemptRun should ===(
+      \/.left(UnexpectedStatus(Status.InternalServerError)))
+  }
+
   "agentListServices" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, dummyServicesReply)
     val csl = constantConsul(response)

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -58,7 +58,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksForService("test", None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.listHealthChecksForNode("localhost", None)).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -16,77 +16,77 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   "get" should "succeed with some when the response is 200" in {
     val response = consulResponse(Status.Ok, "yay")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.get("foo")).attemptRun should ===(
+    helm.run(csl, ConsulOp.kvGet("foo")).attemptRun should ===(
       \/.right(Some("yay")))
   }
 
   "get" should "succeed with none when the response is 404" in {
     val response = consulResponse(Status.NotFound, "nope")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.get("foo")).attemptRun should ===(
+    helm.run(csl, ConsulOp.kvGet("foo")).attemptRun should ===(
       \/.right(None))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "boo")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.get("foo")).attemptRun should ===(
+    helm.run(csl, ConsulOp.kvGet("foo")).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "set" should "succeed when the response is 200" in {
     val response = consulResponse(Status.Ok, "yay")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.set("foo", "bar")).attemptRun should ===(
+    helm.run(csl, ConsulOp.kvSet("foo", "bar")).attemptRun should ===(
       \/.right(()))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "boo")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.set("foo", "bar")).attemptRun should ===(
+    helm.run(csl, ConsulOp.kvSet("foo", "bar")).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
-  "listHealthChecksForNode" should "succeed with the proper result when the response is 200" in {
+  "healthListChecksForNode" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksForNode("localhost", None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None)).attemptRun should ===(
       \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksForNode("localhost", None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None)).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
-  "listHealthChecksInState" should "succeed with the proper result when the response is 200" in {
+  "healthListChecksInState" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
       \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None)).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
-  "listHealthChecksForService" should "succeed with the proper result when the response is 200" in {
+  "healthListChecksForService" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksForService("test", None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None)).attemptRun should ===(
       \/.right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.listHealthChecksForService("test", None, None, None)).attemptRun should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None)).attemptRun should ===(
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -62,6 +62,20 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
       \/.left(UnexpectedStatus(Status.InternalServerError)))
   }
 
+  "agentDeregisterService" should "succeed when the response is 200" in {
+    val response = consulResponse(Status.Ok, "")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentDeregisterService("testService")).attemptRun should ===(
+      \/.right(()))
+  }
+
+  it should "fail when the response is 500" in {
+    val response = consulResponse(Status.InternalServerError, "")
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.agentDeregisterService("testService")).attemptRun should ===(
+      \/.left(UnexpectedStatus(Status.InternalServerError)))
+  }
+
   "agentListServices" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, dummyServicesReply)
     val csl = constantConsul(response)

--- a/http4s/src/test/scala/Integration.scala
+++ b/http4s/src/test/scala/Integration.scala
@@ -70,12 +70,12 @@ class IntegrationSpec
 
   "consul" should "work" in check { (k: String, v: String) =>
     scala.concurrent.Await.result(dockerContainers.head.isReady(), 20.seconds)
-    helm.run(interpreter, ConsulOp.set(k, v)).run
-    helm.run(interpreter, ConsulOp.get(k)).run should be (Some(v))
+    helm.run(interpreter, ConsulOp.kvSet(k, v)).run
+    helm.run(interpreter, ConsulOp.kvGet(k)).run should be (Some(v))
 
-    helm.run(interpreter, ConsulOp.listKeys("")).run should contain (k)
-    helm.run(interpreter, ConsulOp.delete(k)).run
-    helm.run(interpreter, ConsulOp.listKeys("")).run should not contain (k)
+    helm.run(interpreter, ConsulOp.kvListKeys("")).run should contain (k)
+    helm.run(interpreter, ConsulOp.kvDelete(k)).run
+    helm.run(interpreter, ConsulOp.kvListKeys("")).run should not contain (k)
     true
   }(implicitly, implicitly, Arbitrary(Gen.alphaStr suchThat(_.size > 0)), implicitly, implicitly, Arbitrary(Gen.alphaStr), implicitly, implicitly, implicitly[CheckerAsserting[EntityDecoder[String]]], implicitly, implicitly)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.0-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
I'm guessing you're using Registrator or something along those lines to register your services. I need to register services from within my application, so I'm probably gonna add some stuff related to deregistering services and adding health checks in addition to this commit. Let me know if you have any preferences on design surrounding agent-based actions vs. more generic API calls, and of course I am happy to change formatting or JSON generation or whatever as you desire!

Personally I think it's probably OK to have everything in one place, especially since ConsulOp is sealed, though it's gonna get kinda long if every API call is implemented.

p.s. I'm using Sublime rather than an IDE, and your wildcard imports kill me a little bit every time I have to figure out where types are coming from. ;)