### PR TITLE
Add support for blocking queries, and made KV store functionality use Array[Byte] instead of String

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ a base url for consul:
 import cats.effect.IO
 import helm.http4s._
 import org.http4s.Uri.uri
-import org.http4s.client.blaze.PooledHttp1Client
+import org.http4s.client.blaze.Http1Client
 
-val client = PooledHttp1Client[IO]()
+val client = Http1Client[IO]().unsafeRunSync
 val baseUrl = uri("http://127.0.0.1:8500")
 
 val interpreter = new Http4sConsulClient(baseUrl, client)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ examples are `get` and `set`:
 import helm._
 import ConsulOp.ConsulOpF
 
-val s: ConsulOpF[Unit] = : ConsulOp.set("key", "value")
+val s: ConsulOpF[Unit] = : ConsulOp.kvSet("key", "value")
 
-val g: ConsulOpF[Option[String]] = : ConsulOp.get("key")
+val g: ConsulOpF[Option[String]] = : ConsulOp.kvGet("key")
 ```
 
 These are however just descriptions of what operations the program might perform in the future, just creating these operations does not
@@ -39,32 +39,33 @@ First we create an interpreter, which requires an http4s client and
 a base url for consul:
 
 ```
+import cats.effect.IO
 import helm.http4s._
 import org.http4s.Uri.uri
 import org.http4s.client.blaze.PooledHttp1Client
 
-val client = PooledHttp1Client()
+val client = PooledHttp1Client[IO]()
 val baseUrl = uri("http://127.0.0.1:8500")
 
 val interpreter = new Http4sConsulClient(baseUrl, client)
 ```
 
-Now we can apply commands to our http4s client to get back Tasks
+Now we can apply commands to our http4s client to get back IOs
 which actually interact with consul.
 
 ```
-import scalaz.concurrent.Task
+import cats.effect.IO
 
-val s: Task[Unit] = helm.run(interpreter, ConsulOp.set("testkey", "testvalue"))
+val s: IO[Unit] = helm.run(interpreter, ConsulOp.kvSet("testkey", "testvalue"))
 
-val g: Task[Option[String]] = helm.run(interpreter, ConsulOp.get("testkey"))
+val g: IO[Option[String]] = helm.run(interpreter, ConsulOp.kvGet("testkey"))
 
 // actually execute the calls
-s.run
-g.run
+s.unsafeRunSync
+g.unsafeRunSync
 ```
 
-Typically, the *Helm* algebra would be a part of a `Coproduct` with other algebras in a larger program, so running the `Task` immediately after `helm.run` is not typical.
+Typically, the *Helm* algebra would be a part of a `Coproduct` with other algebras in a larger program, so running the `IO` immediately after `helm.run` is not typical.
 
 ## Contributing
 

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -5,15 +5,28 @@ import argonaut.{DecodeJson, EncodeJson, StringWrap}, StringWrap.StringToParseWr
 import cats.data.NonEmptyList
 import cats.free.Free
 import cats.free.Free.liftF
-import cats.implicits._
+//import cats.implicits._
 
 sealed abstract class ConsulOp[A] extends Product with Serializable
 
 object ConsulOp {
 
-  final case class KVGet(key: Key) extends ConsulOp[Option[String]]
+  final case class KVGet(
+    key:        Key,
+    recurse:    Option[Boolean],
+    datacenter: Option[String],
+    separator:  Option[String],
+    index:      Option[Long],
+    maxWait:    Option[Interval]
+  ) extends ConsulOp[QueryResponse[List[KVGetResult]]]
 
-  final case class KVSet(key: Key, value: String) extends ConsulOp[Unit]
+  final case class KVGetRaw(
+    key:     Key,
+    index:   Option[Long],
+    maxWait: Option[Interval]
+  ) extends ConsulOp[QueryResponse[Option[Array[Byte]]]]
+
+  final case class KVSet(key: Key, value: Array[Byte]) extends ConsulOp[Unit]
 
   final case class KVDelete(key: Key) extends ConsulOp[Unit]
 
@@ -75,17 +88,42 @@ object ConsulOp {
 
   type ConsulOpF[A] = Free[ConsulOp, A]
 
-  def kvGet(key: Key): ConsulOpF[Option[String]] =
-    liftF(KVGet(key))
+  def kvGet(
+    key:        Key,
+    recurse:    Option[Boolean],
+    datacenter: Option[String],
+    separator:  Option[String],
+    index:      Option[Long],
+    maxWait:    Option[Interval]
+  ): ConsulOpF[QueryResponse[List[KVGetResult]]] =
+    liftF(KVGet(key, recurse, datacenter, separator, index, maxWait))
 
-  def kvGetJson[A:DecodeJson](key: Key): ConsulOpF[Either[Err, Option[A]]] =
-    kvGet(key).map(_.traverse(_.decodeEither[A]))
+  def kvGetRaw(
+    key:   Key,
+    index: Option[Long],
+    maxWait:    Option[Interval]
+  ): ConsulOpF[QueryResponse[Option[Array[Byte]]]] =
+    liftF(KVGetRaw(key, index, maxWait))
 
-  def kvSet(key: Key, value: String): ConsulOpF[Unit] =
+  def kvGetJson[A:DecodeJson](
+    key:     Key,
+    index:   Option[Long],
+    maxWait: Option[Interval]
+  ): ConsulOpF[Either[Err, QueryResponse[Option[A]]]] =
+    kvGetRaw(key, index, maxWait).map { response =>
+      response.value match {
+        case Some(bytes) =>
+          new String(bytes).decodeEither[A].right.map(decoded => response.copy(value = Some(decoded)))
+        case None =>
+          Right(response.copy(value = None))
+      }
+    }
+
+  def kvSet(key: Key, value: Array[Byte]): ConsulOpF[Unit] =
     liftF(KVSet(key, value))
 
   def kvSetJson[A](key: Key, value: A)(implicit A: EncodeJson[A]): ConsulOpF[Unit] =
-    kvSet(key, A.encode(value).toString)
+    kvSet(key, A.encode(value).toString.getBytes)
 
   def kvDelete(key: Key): ConsulOpF[Unit] =
     liftF(KVDelete(key))

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -24,13 +24,15 @@ object ConsulOp {
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   final case class HealthListChecksForNode(
     node:       String,
     datacenter: Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   final case class HealthListChecksInState(
@@ -38,7 +40,8 @@ object ConsulOp {
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   // There's also a Catalog function called List Nodes for Service
@@ -49,7 +52,8 @@ object ConsulOp {
     nodeMeta:    Option[String],
     tag:         Option[String],
     passingOnly: Option[Boolean],
-    index:       Option[Long]
+    index:       Option[Long],
+    maxWait:     Option[Interval]
   ) extends ConsulOp[QueryResponse[List[HealthNodesForServiceResponse]]]
 
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
@@ -94,25 +98,28 @@ object ConsulOp {
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
-    liftF(HealthListChecksForService(service, datacenter, near, nodeMeta, index))
+    liftF(HealthListChecksForService(service, datacenter, near, nodeMeta, index, maxWait))
 
   def healthListChecksForNode(
     node:       String,
     datacenter: Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
-    liftF(HealthListChecksForNode(node, datacenter, index))
+    liftF(HealthListChecksForNode(node, datacenter, index, maxWait))
 
   def healthListChecksInState(
     state:      HealthStatus,
     datacenter: Option[String],
     near:       Option[String],
     nodeMeta:   Option[String],
-    index:      Option[Long]
+    index:      Option[Long],
+    maxWait:    Option[Interval]
   ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
-    liftF(HealthListChecksInState(state, datacenter, near, nodeMeta, index))
+    liftF(HealthListChecksInState(state, datacenter, near, nodeMeta, index, maxWait))
 
   def healthListNodesForService(
     service:     String,
@@ -121,9 +128,10 @@ object ConsulOp {
     nodeMeta:    Option[String],
     tag:         Option[String],
     passingOnly: Option[Boolean],
-    index:       Option[Long]
+    index:       Option[Long],
+    maxWait:     Option[Interval]
   ): ConsulOpF[QueryResponse[List[HealthNodesForServiceResponse]]] =
-    liftF(HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly, index))
+    liftF(HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly, index, maxWait))
 
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     liftF(AgentListServices)

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -5,7 +5,6 @@ import argonaut.{DecodeJson, EncodeJson, StringWrap}, StringWrap.StringToParseWr
 import cats.data.NonEmptyList
 import cats.free.Free
 import cats.free.Free.liftF
-//import cats.implicits._
 
 sealed abstract class ConsulOp[A] extends Product with Serializable
 
@@ -113,7 +112,7 @@ object ConsulOp {
     kvGetRaw(key, index, maxWait).map { response =>
       response.value match {
         case Some(bytes) =>
-          new String(bytes).decodeEither[A].right.map(decoded => response.copy(value = Some(decoded)))
+          new String(bytes, "UTF-8").decodeEither[A].right.map(decoded => response.copy(value = Some(decoded)))
         case None =>
           Right(response.copy(value = None))
       }
@@ -123,7 +122,7 @@ object ConsulOp {
     liftF(KVSet(key, value))
 
   def kvSetJson[A](key: Key, value: A)(implicit A: EncodeJson[A]): ConsulOpF[Unit] =
-    kvSet(key, A.encode(value).toString.getBytes)
+    kvSet(key, A.encode(value).toString.getBytes("UTF-8"))
 
   def kvDelete(key: Key): ConsulOpF[Unit] =
     liftF(KVDelete(key))

--- a/core/src/main/scala/HelmOp.scala
+++ b/core/src/main/scala/HelmOp.scala
@@ -23,20 +23,23 @@ object ConsulOp {
     service:    String,
     datacenter: Option[String],
     near:       Option[String],
-    nodeMeta:   Option[String]
-  ) extends ConsulOp[List[HealthCheckResponse]]
+    nodeMeta:   Option[String],
+    index:      Option[Long]
+  ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   final case class HealthListChecksForNode(
     node:       String,
-    datacenter: Option[String]
-  ) extends ConsulOp[List[HealthCheckResponse]]
+    datacenter: Option[String],
+    index:      Option[Long]
+  ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   final case class HealthListChecksInState(
     state:      HealthStatus,
     datacenter: Option[String],
     near:       Option[String],
-    nodeMeta:   Option[String]
-  ) extends ConsulOp[List[HealthCheckResponse]]
+    nodeMeta:   Option[String],
+    index:      Option[Long]
+  ) extends ConsulOp[QueryResponse[List[HealthCheckResponse]]]
 
   // There's also a Catalog function called List Nodes for Service
   final case class HealthListNodesForService(
@@ -45,8 +48,9 @@ object ConsulOp {
     near:        Option[String],
     nodeMeta:    Option[String],
     tag:         Option[String],
-    passingOnly: Option[Boolean]
-  ) extends ConsulOp[List[HealthNodesForServiceResponse]]
+    passingOnly: Option[Boolean],
+    index:       Option[Long]
+  ) extends ConsulOp[QueryResponse[List[HealthNodesForServiceResponse]]]
 
   final case object AgentListServices extends ConsulOp[Map[String, ServiceResponse]]
 
@@ -89,23 +93,26 @@ object ConsulOp {
     service:    String,
     datacenter: Option[String],
     near:       Option[String],
-    nodeMeta:   Option[String]
-  ): ConsulOpF[List[HealthCheckResponse]] =
-    liftF(HealthListChecksForService(service, datacenter, near, nodeMeta))
+    nodeMeta:   Option[String],
+    index:      Option[Long]
+  ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
+    liftF(HealthListChecksForService(service, datacenter, near, nodeMeta, index))
 
   def healthListChecksForNode(
     node:       String,
-    datacenter: Option[String]
-  ): ConsulOpF[List[HealthCheckResponse]] =
-    liftF(HealthListChecksForNode(node, datacenter))
+    datacenter: Option[String],
+    index:      Option[Long]
+  ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
+    liftF(HealthListChecksForNode(node, datacenter, index))
 
   def healthListChecksInState(
     state:      HealthStatus,
     datacenter: Option[String],
     near:       Option[String],
-    nodeMeta:   Option[String]
-  ): ConsulOpF[List[HealthCheckResponse]] =
-    liftF(HealthListChecksInState(state, datacenter, near, nodeMeta))
+    nodeMeta:   Option[String],
+    index:      Option[Long]
+  ): ConsulOpF[QueryResponse[List[HealthCheckResponse]]] =
+    liftF(HealthListChecksInState(state, datacenter, near, nodeMeta, index))
 
   def healthListNodesForService(
     service:     String,
@@ -113,9 +120,10 @@ object ConsulOp {
     near:        Option[String],
     nodeMeta:    Option[String],
     tag:         Option[String],
-    passingOnly: Option[Boolean]
-  ): ConsulOpF[List[HealthNodesForServiceResponse]] =
-    liftF(HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly))
+    passingOnly: Option[Boolean],
+    index:       Option[Long]
+  ): ConsulOpF[QueryResponse[List[HealthNodesForServiceResponse]]] =
+    liftF(HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly, index))
 
   def agentListServices(): ConsulOpF[Map[String, ServiceResponse]] =
     liftF(AgentListServices)

--- a/core/src/main/scala/KVGetResult.scala
+++ b/core/src/main/scala/KVGetResult.scala
@@ -1,0 +1,36 @@
+package helm
+
+import argonaut._, Argonaut._
+
+/** Case class representing the response to a KV "Read Key" API call to Consul */
+final case class KVGetResult(
+  key:         String,
+  value:       String,
+  flags:       Long,
+  session:     Option[String],
+  lockIndex:   Long,
+  createIndex: Long,
+  modifyIndex: Long
+)
+
+object KVGetResult {
+  implicit def KVGetResultDecoder: DecodeJson[KVGetResult] =
+    DecodeJson(j =>
+      for {
+        key         <- (j --\ "Key").as[String]
+        value       <- (j --\ "Value").as[String]
+        flags       <- (j --\ "Flags").as[Long]
+        session     <- (j --\ "Session").as[Option[String]]
+        lockIndex   <- (j --\ "LockIndex").as[Long]
+        createIndex <- (j --\ "CreateIndex").as[Long]
+        modifyIndex <- (j --\ "ModifyIndex").as[Long]
+      } yield KVGetResult(
+        key,
+        value,
+        flags,
+        session,
+        lockIndex,
+        createIndex,
+        modifyIndex)
+    )
+}

--- a/core/src/main/scala/QueryResponse.scala
+++ b/core/src/main/scala/QueryResponse.scala
@@ -1,0 +1,15 @@
+package helm
+
+/**
+  * Representative of a response from Consul for an API call querying data, including
+  * the values of the headers X-Consul-Index, X-Consul-Knownleader, and X-Consul-Lastcontact
+  * Note that the following APIs are known not to return these headers (as of Consul v1.0.6):
+  *   - Anything under /agent/
+  *   - /catalog/datacenters
+  */
+final case class QueryResponse[A](
+  value:       A,
+  index:       Long,
+  knownLeader: Boolean,
+  lastContact: Long
+)

--- a/core/src/test/scala/ConsulOpTests.scala
+++ b/core/src/test/scala/ConsulOpTests.scala
@@ -11,29 +11,28 @@ class ConsulOpTests extends FlatSpec with Matchers with TypeCheckedTripleEquals 
 
   "getJson" should "return none right when get returns None" in {
     val interp = for {
-      _ <- I.expectU[Option[String]] {
-        case ConsulOp.KVGet("foo") => IO.pure(None)
+      _ <- I.expectU[QueryResponse[Option[Array[Byte]]]] {
+        case ConsulOp.KVGetRaw("foo", None, None) => IO.pure(QueryResponse(None, -1, true, -1))
       }
     } yield ()
-    interp.run(kvGetJson[Json]("foo")).unsafeRunSync should equal(Right(None))
+    interp.run(kvGetJson[Json]("foo", None, None)).unsafeRunSync should equal(Right(QueryResponse(None, -1, true, -1)))
   }
 
   it should "return a value when get returns a decodeable value" in {
     val interp = for {
-      _ <- I.expectU[Option[String]] {
-        case ConsulOp.KVGet("foo") => IO.pure(Some("42"))
+      _ <- I.expectU[QueryResponse[Option[Array[Byte]]]] {
+        case ConsulOp.KVGetRaw("foo", None, None) => IO.pure(QueryResponse(Some("42".getBytes), -1, true, -1))
       }
     } yield ()
-    interp.run(kvGetJson[Json]("foo")).unsafeRunSync should equal(Right(Some(jNumber(42))))
+    interp.run(kvGetJson[Json]("foo", None, None)).unsafeRunSync should equal(Right(QueryResponse(Some(jNumber(42)), -1, true, -1)))
   }
 
   it should "return an error when get returns a non-decodeable value" in {
     val interp = for {
-      _ <- I.expectU[Option[String]] {
-        case ConsulOp.KVGet("foo") => IO.pure(Some("{"))
+      _ <- I.expectU[QueryResponse[Option[Array[Byte]]]] {
+        case ConsulOp.KVGetRaw("foo", None, None) => IO.pure(QueryResponse(Some("{".getBytes), -1, true, -1))
       }
     } yield ()
-    interp.run(kvGetJson[Json]("foo")).unsafeRunSync should equal(Left("JSON terminates unexpectedly."))
+    interp.run(kvGetJson[Json]("foo", None, None)).unsafeRunSync should equal(Left("JSON terminates unexpectedly."))
   }
 }
-

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -1,6 +1,6 @@
 
 val http4sOrg = "org.http4s"
-val http4sVersion = "0.18.4"
+val http4sVersion = "0.18.11"
 val dockeritVersion = "0.9.0"
 
 scalaTestVersion  := "3.0.1"

--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -163,7 +163,7 @@ final class Http4sConsulClient[F[_]](
           case status@(Status.Ok|Status.NotFound) =>
             for {
               headers <- extractConsulHeaders(response)
-              value   <- if (status == Status.Ok) response.body.compile.toVector.map(vec => Some(vec.toArray)) else F.pure(None)
+              value   <- if (status == Status.Ok) response.body.compile.to[Array].map(arr => Some(arr)) else F.pure(None)
             } yield {
               QueryResponse(value, headers.index, headers.knownLeader, headers.lastContact)
             }

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -5,10 +5,11 @@ import cats.~>
 import cats.data.Kleisli
 import cats.effect.IO
 import fs2.{Chunk, Stream}
-import org.http4s.{EntityBody, Request, Response, Status, Uri}
+import org.http4s.{EntityBody, Header, Headers, Request, Response, Status, Uri}
 import org.http4s.client._
 import org.scalatest._
 import org.scalactic.TypeCheckedTripleEquals
+import org.http4s.syntax.string.http4sStringSyntax
 
 class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEquals {
   import Http4sConsulTests._
@@ -49,58 +50,88 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   }
 
   "healthListChecksForNode" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
-    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
+    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListChecksInState" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
-    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
+    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListChecksForService" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson)
+    val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
-    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored")
+    val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListNodesForService" should "succeed with the proper result when the response is 200" in {
-    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson)
+    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthNodesForServiceReturnValue))
   }
 
-  it should "fail when the response is 500" in {
-    val response = consulResponse(Status.InternalServerError, "aww yeah")
+  "healthListNodesForService" should "fail if X-Consul-Index is omitted" in {
+    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-Index".ci))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None)).attempt.unsafeRunSync should ===(
+
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+      case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-Index")
+      case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-Index), but got $other")
+    }
+  }
+
+  "healthListNodesForService" should "fail if X-Consul-KnownLeader is omitted" in {
+    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-KnownLeader".ci))
+    val csl = constantConsul(response)
+
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+      case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-KnownLeader")
+      case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-KnownLeader), but got $other")
+    }
+  }
+
+  "healthListNodesForService" should "fail if X-Consul-LastContact is omitted" in {
+    val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-LastContact".ci))
+    val csl = constantConsul(response)
+
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+      case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-LastContact")
+      case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-LastContact), but got $other")
+    }
+  }
+
+  it should "fail when the response is 500" in {
+    val response = consulResponse(Status.InternalServerError, "aww yeah", consulHeaders(1234, true, 0))
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
@@ -174,9 +205,19 @@ object Http4sConsulTests {
       None)
   }
 
-  def consulResponse(status: Status, s: String): Response[IO] = {
+  def consulHeaders(index: Long, knownLeader: Boolean, lastContact: Long): Headers = {
+    Headers(
+      List(
+        Header.Raw("X-Consul-Index".ci, index.toString),
+        Header.Raw("X-Consul-KnownLeader".ci, knownLeader.toString),
+        Header.Raw("X-Consul-LastContact".ci, lastContact.toString)
+      )
+    )
+  }
+
+  def consulResponse(status: Status, s: String, headers: Headers = Headers.empty): Response[IO] = {
     val responseBody = body(s)
-    Response(status = status, body = responseBody)
+    Response(status = status, body = responseBody, headers = headers)
   }
 
   def constantResponseClient(response: Response[IO]): Client[IO] = {
@@ -313,83 +354,93 @@ object Http4sConsulTests {
   """
 
   val healthNodesForServiceReturnValue =
-    List(
-      HealthNodesForServiceResponse(
-        NodeResponse(
-          "cb1f6030-a220-4f92-57dc-7baaabdc3823",
-          "localhost",
-          "192.168.1.145",
-          "dc1",
-          Map("metaTest" -> "test123"),
-          TaggedAddresses("192.168.1.145", "192.168.2.145"),
-          123455121311L,
-          123455121347L
-        ),
-        ServiceResponse(
-          "testService",
-          "test",
-          List("testTag",
-          "anotherTag"),
-          "127.0.0.1",
-          1234,
-          false,
-          123455121301L,
-          123455121322L
-        ),
-        List(
-          HealthCheckResponse(
+    QueryResponse(
+      List(
+        HealthNodesForServiceResponse(
+          NodeResponse(
+            "cb1f6030-a220-4f92-57dc-7baaabdc3823",
             "localhost",
-            "service:testService",
-            "Service 'testService' check",
-            HealthStatus.Passing,
-            "test note",
-            "HTTP GET https://test.test.test/: 200 OK Output: all's well",
-            "testServiceID",
-            "testServiceName",
-            List("testTag"),
-            19008L,
-            19013L),
-          HealthCheckResponse(
-            "localhost",
-            "service:testService#2",
-            "other check",
-            HealthStatus.Critical,
-            "a note",
-            "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
-            "testServiceID",
-            "testServiceName",
-            List("testTag", "anotherTag"),
-            123455121300L,
-            123455121321L)
+            "192.168.1.145",
+            "dc1",
+            Map("metaTest" -> "test123"),
+            TaggedAddresses("192.168.1.145", "192.168.2.145"),
+            123455121311L,
+            123455121347L
+          ),
+          ServiceResponse(
+            "testService",
+            "test",
+            List("testTag",
+            "anotherTag"),
+            "127.0.0.1",
+            1234,
+            false,
+            123455121301L,
+            123455121322L
+          ),
+          List(
+            HealthCheckResponse(
+              "localhost",
+              "service:testService",
+              "Service 'testService' check",
+              HealthStatus.Passing,
+              "test note",
+              "HTTP GET https://test.test.test/: 200 OK Output: all's well",
+              "testServiceID",
+              "testServiceName",
+              List("testTag"),
+              19008L,
+              19013L),
+            HealthCheckResponse(
+              "localhost",
+              "service:testService#2",
+              "other check",
+              HealthStatus.Critical,
+              "a note",
+              "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
+              "testServiceID",
+              "testServiceName",
+              List("testTag", "anotherTag"),
+              123455121300L,
+              123455121321L)
+          )
         )
-      )
-    )
+    ),
+    1234,
+    true,
+    0
+  )
 
   val healthStatusReplyJson =
-    List(
-      HealthCheckResponse(
-        "localhost",
-        "service:testService",
-        "Service 'testService' check",
-        HealthStatus.Passing,
-        "test note",
-        "HTTP GET https://test.test.test/: 200 OK Output: all's well",
-        "testServiceID",
-        "testServiceName",
-        List("testTag"),
-        19008L,
-        19013L),
-      HealthCheckResponse(
-        "localhost",
-        "service:testService#2",
-        "other check",
-        HealthStatus.Critical,
-        "a note",
-        "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
-        "testServiceID",
-        "testServiceName",
-        List("testTag", "anotherTag"),
-        123455121300L,
-        123455121321L)
+    QueryResponse(
+      List(
+        HealthCheckResponse(
+          "localhost",
+          "service:testService",
+          "Service 'testService' check",
+          HealthStatus.Passing,
+          "test note",
+          "HTTP GET https://test.test.test/: 200 OK Output: all's well",
+          "testServiceID",
+          "testServiceName",
+          List("testTag"),
+          19008L,
+          19013L),
+        HealthCheckResponse(
+          "localhost",
+          "service:testService#2",
+          "other check",
+          HealthStatus.Critical,
+          "a note",
+          "Get https://test.test.test/: dial tcp 192.168.1.71:443: getsockopt: connection refused",
+          "testServiceID",
+          "testServiceName",
+          List("testTag", "anotherTag"),
+          123455121300L,
+          123455121321L)
+      ),
+      1234,
+      true,
+      0
     )
 }

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -52,49 +52,49 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   "healthListChecksForNode" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForNode("localhost", None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListChecksInState" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksInState(HealthStatus.Passing, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListChecksForService" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, serviceHealthChecksReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthStatusReplyJson))
   }
 
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "doesn't actually matter since this part is ignored", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListChecksForService("test", None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 
   "healthListNodesForService" should "succeed with the proper result when the response is 200" in {
     val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Right(healthNodesForServiceReturnValue))
   }
 
@@ -102,7 +102,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
     val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-Index".ci))
     val csl = constantConsul(response)
 
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None, None)).attempt.unsafeRunSync match {
       case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-Index")
       case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-Index), but got $other")
     }
@@ -112,7 +112,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
     val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-KnownLeader".ci))
     val csl = constantConsul(response)
 
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None, None)).attempt.unsafeRunSync match {
       case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-KnownLeader")
       case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-KnownLeader), but got $other")
     }
@@ -122,7 +122,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
     val response = consulResponse(Status.Ok, healthNodesForServiceReplyJson, consulHeaders(1234, true, 0).filter(_.name != "X-Consul-LastContact".ci))
     val csl = constantConsul(response)
 
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync match {
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None, None)).attempt.unsafeRunSync match {
       case Left(re: RuntimeException) => assert(re.getMessage === "Header not present in response: X-Consul-LastContact")
       case other => fail(s"Expected RuntimeException(Header not present in response: X-Consul-LastContact), but got $other")
     }
@@ -131,7 +131,7 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "aww yeah", consulHeaders(1234, true, 0))
     val csl = constantConsul(response)
-    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
+    helm.run(csl, ConsulOp.healthListNodesForService("test", None, None, None, None, None, None, None)).attempt.unsafeRunSync should ===(
       Left(UnexpectedStatus(Status.InternalServerError)))
   }
 


### PR DESCRIPTION
Lots of breaking changes to the APIs here, sorry. No good way around it.

Give me your worst on the review. I'm open to whatever changes.

Also, it doesn't seem that the Docker integration tests work on Mac OS X so I had to do some hacky stuff to get the tests to run against my local Consul instance, but I'm pretty sure the integration tests work correctly and are effective.

P.S. this fixes #8 