### PR TITLE
Fix KVGetResult scheme to match Consul API

### DIFF
--- a/core/src/main/scala/KVGetResult.scala
+++ b/core/src/main/scala/KVGetResult.scala
@@ -5,7 +5,7 @@ import argonaut._, Argonaut._
 /** Case class representing the response to a KV "Read Key" API call to Consul */
 final case class KVGetResult(
   key:         String,
-  value:       String,
+  value:       Option[String],
   flags:       Long,
   session:     Option[String],
   lockIndex:   Long,
@@ -18,7 +18,7 @@ object KVGetResult {
     DecodeJson(j =>
       for {
         key         <- (j --\ "Key").as[String]
-        value       <- (j --\ "Value").as[String]
+        value       <- (j --\ "Value").as[Option[String]]
         flags       <- (j --\ "Flags").as[Long]
         session     <- (j --\ "Session").as[Option[String]]
         lockIndex   <- (j --\ "LockIndex").as[Long]

--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -167,7 +167,12 @@ final class Http4sConsulClient[F[_]](
           case status@(Status.Ok|Status.NotFound) =>
             for {
               headers <- extractConsulHeaders(response)
-              value   <- if (status == Status.Ok) response.body.compile.to[Array].map(Some(_)) else F.pure(None)
+              value   <- if (status == Status.Ok) {
+                response.body.compile.to[Array].map {
+                  case Array() => None
+                  case nonEmpty => Some(nonEmpty)
+                }
+              } else F.pure(None)
             } yield {
               QueryResponse(value, headers.index, headers.knownLeader, headers.lastContact)
             }

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -364,7 +364,7 @@ object Http4sConsulTests {
   [
       {
           "Key": "foo",
-          "Value": "YmFy",
+          "Value": null,
           "Flags": 0,
           "LockIndex": 0,
           "CreateIndex": 43788,
@@ -385,8 +385,8 @@ object Http4sConsulTests {
   val kvGetReturnValue =
     QueryResponse(
       List(
-        KVGetResult("foo", "YmFy", 0, None, 0, 43788, 43789),
-        KVGetResult("foo/baz", "cXV4", 1234, Some("adf4238a-882b-9ddc-4a9d-5b6758e4159e"), 0, 43790, 43791)
+        KVGetResult("foo", None, 0, None, 0, 43788, 43789),
+        KVGetResult("foo/baz", Some("cXV4"), 1234, Some("adf4238a-882b-9ddc-4a9d-5b6758e4159e"), 0, 43790, 43791)
       ),
       555,
       false,

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -31,6 +31,13 @@ class Http4sConsulTests extends FlatSpec with Matchers with TypeCheckedTripleEqu
       Right(QueryResponse[Option[Array[Byte]]](None, 999, false, 1)))
   }
 
+  "kvGetRaw" should "succeed with none when the response body is empty" in {
+    val response = consulResponse(Status.Ok, "", consulHeaders(999, false, 1))
+    val csl = constantConsul(response)
+    helm.run(csl, ConsulOp.kvGetRaw("foo", None, None)).attempt.unsafeRunSync should ===(
+      Right(QueryResponse[Option[Array[Byte]]](None, 999, false, 1)))
+  }
+
   it should "fail when the response is 500" in {
     val response = consulResponse(Status.InternalServerError, "error")
     val csl = constantConsul(response)


### PR DESCRIPTION
Actually `Value` field in Consul API is optional and deserialization fails if key value is null.

curl -X PUT localhost:8500/v1/kv/foo/
`true`
curl localhost:8500/v1/kv/foo/
```
[
    {
        "LockIndex": 0,
        "Key": "foo/",
        "Flags": 0,
        "Value": null,
        "CreateIndex": 21,
        "ModifyIndex": 21
    }
]
```