### PR TITLE
Fixed bug in Http4sConsul#kvGet where recurse value of Some(false) still invokes Consul's recursive key lookup

### DIFF
--- a/http4s/src/main/scala/Http4sConsul.scala
+++ b/http4s/src/main/scala/Http4sConsul.scala
@@ -124,7 +124,7 @@ final class Http4sConsulClient[F[_]](
         Request(
           uri =
             (baseUri / "v1" / "kv" / key)
-              .+??("recurse", recurse)
+              .+??("recurse", recurse.filter(identity))
               .+??("dc", datacenter)
               .+??("separator", separator)
               .+??("index", index)


### PR DESCRIPTION
Just a minor bug fix. Consul ignores the value of boolean parameters and assumes they are true if they are present, so `?recurse=false` is the same as `?recurse` or `?recurse=true`.